### PR TITLE
fix: allow any version of markdown-it above 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prepare": "simple-git-hooks"
   },
   "peerDependencies": {
-    "markdown-it": "^14.0.0"
+    "markdown-it": ">= 13.0.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.6.1",


### PR DESCRIPTION
### Description

This PR fixes warnings about unmet peer dependencies; similar to https://github.com/antfu/markdown-it-github-alerts/pull/4, but future-proof. I'm currently using `markdown-it@14.1.0`, triggering the warning as the peer dependency only allows versions `14.0.x`. I set the minimum version to 13 given it was previously changed to 14 only to fix this error; compatibility was not affected since then.

See also [semver range syntax](https://github.com/npm/node-semver#versions).
